### PR TITLE
chore: Replace pydantic-ai with pydantic-ai-slim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Typing :: Typed",
 ]
-dependencies = ["pydantic-ai>=0.1.0"]
+dependencies = ["pydantic-ai-slim[cli]>=0.1.0"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "mypy>=1.0", "ruff>=0.1"]


### PR DESCRIPTION
## Changes

### Summary

- Replace `pydantic-ai` package with `pydantic-ai-slim` to reduce unnecessary dependencies.
